### PR TITLE
Bump up version of unicreds used in stealth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,40 +3,52 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:f49992aa22f94ae0e95584bf39cdb7248d436072f535d2e66c4922dd5250a5df"
   name = "github.com/Clever/unicreds"
   packages = ["."]
-  revision = "8ddef5f30943fe4a9c59fa3cc1339e8cb8a54df2"
+  pruneopts = ""
+  revision = "77b6fde6928dcf9efb9cebe12de277516677150d"
 
 [[projects]]
+  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
   name = "github.com/alecthomas/kingpin"
   packages = ["."]
-  revision = "e5900212cbf65b181d3d8e08308ef06a01d117cf"
-  version = "v2.2.2"
+  pruneopts = ""
+  revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
+  version = "v2.2.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:a7f619ffc7b99687f9444bd0a07509fec8ae708a7175d234878129896c0918a8"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
-  revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
+  pruneopts = ""
+  revision = "fb15b899a75114aa79cc930e33c46b577cc664b1"
 
 [[projects]]
   branch = "master"
+  digest = "1:9d943843b71c5d44f184893fcdbe419bf639fee8647ceeca4c7d4fd95923721c"
   name = "github.com/alecthomas/units"
   packages = ["."]
-  revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
+  pruneopts = ""
+  revision = "f65c72e2690dc4b403c8bd637baf4611cd4c069b"
 
 [[projects]]
+  digest = "1:ae00e2ff18d31ca63336e52f93bf0d298eda9f35e9504b54ad7640c6845603c0"
   name = "github.com/apex/log"
   packages = [
     ".",
-    "handlers/json"
+    "handlers/json",
   ]
-  revision = "8eba30e442954605fd2e1a542912d5b5e16cab13"
+  pruneopts = ""
+  revision = "295021f518f737dd0bfdca2c98136517703196b9"
+  version = "v1.1.1"
 
 [[projects]]
+  digest = "1:1cee6a7952651c593cb3a2dcddac7f9e13ca17d28e5af6f8c12c7e8d6fb831f4"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -48,14 +60,21 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
+    "aws/crr",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkmath",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/json/jsonutil",
@@ -69,51 +88,86 @@
     "service/dynamodb/dynamodbiface",
     "service/kms",
     "service/kms/kmsiface",
-    "service/sts"
+    "service/sts",
+    "service/sts/stsiface",
   ]
-  revision = "63324a33d7e42a386c04d4daec764a3de243492e"
-  version = "v1.13.0"
+  pruneopts = ""
+  revision = "31767fe4cf2e7e969e2245ab694e21f85015e24b"
+  version = "v1.25.41"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
-
-[[projects]]
+  digest = "1:13fe471d0ed891e8544eddfeeb0471fd3c9f2015609a1c000aefdedf52a19d40"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "0b12d6b5"
+  pruneopts = ""
+  revision = "c2b33e84"
 
 [[projects]]
+  digest = "1:34a65952cd73805b87ca5e89d9dd11f347be3ba88a9a8907244d21a8eb1be1c7"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
-  revision = "d6bea18f789704b5f83375793155289da36a3c7f"
-  version = "v0.0.1"
+  pruneopts = ""
+  revision = "f93a0d58d5fd95e53f82782d07bb0c79d23e1290"
+  version = "v0.0.6"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a2f072281f9b537f0b947964d41cf160c083b7b66638824c04356f87402a6841"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
-  revision = "daf2955e742cf123959884fdff4685aa79b63135"
+  pruneopts = ""
+  revision = "28c9868472de5b61d0a79f4c468103b80487f6c1"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
+  digest = "1:f7b541897bcde05a04a044c342ddc7425aab7e331f37b47fbb486cd16324b48e"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "d77da356e56a7428ad25149ca77381849a6a5232"
+  pruneopts = ""
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
+
+[[projects]]
+  digest = "1:5a53f6ef09fb1ac261a97f8a72e8837ff53cbaa969022a6679da210e4cbe9b0f"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
+  version = "v2.2.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b4d5c2f1ba64b4ba400ceda36b30d974e11c066dd5a7692919d2f2a8ae95981c"
+  input-imports = [
+    "github.com/Clever/unicreds",
+    "github.com/alecthomas/kingpin",
+    "github.com/apex/log",
+    "github.com/apex/log/handlers/json",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/stretchr/testify/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,7 @@
 
 [[constraint]]
   name = "github.com/Clever/unicreds"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/alecthomas/kingpin"

--- a/store/unicreds_store.go
+++ b/store/unicreds_store.go
@@ -199,7 +199,7 @@ func (s *UnicredsStore) History(id SecretIdentifier) ([]SecretMeta, error) {
 // NewUnicredsStore creates a secret store that points at DynamoDB and KMS AWS resources
 func NewUnicredsStore() *UnicredsStore {
 	log.SetHandler(json.New(os.Stderr))
-	unicreds.SetAwsConfig(aws.String(Region), nil)
+	unicreds.SetAwsConfig(aws.String(Region), nil, nil)
 	unicreds.SetDynamoDBConfig(&aws.Config{Region: aws.String(Region), MaxRetries: aws.Int(5)})
 	environments := make(map[Environment]UnicredsConfig)
 	environments[ProductionEnvironment] = Production


### PR DESCRIPTION
Reading secrets using stealth (and leveraging an older version of unicreds)
wasn't possible because of new functions exposed in unicreds that stealth did
not have (due to older versions). Bump up the version of unicreds in stealth so
that this does not happen.