### PR TITLE
Fix publishing via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,4 @@ jobs:
     - run: make install_deps
     - run: make build
     - run: make test
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;


### PR DESCRIPTION
If we specify `./github-release $GH_RELEASE_TOKEN release`, the script
looks for the release artifact (in CircleCI) to then publish.

We're not building the binary here; we're primarily concerned with
tagging the newest version of the library. So, we omit the last parameter
to publish just the code.