### PR TITLE
Secng 385 tags new secrets

### DIFF
--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -81,25 +81,18 @@ func getParamNameFromName(id SecretIdentifier) string {
 
 // getTagsFromName takes the SecretIdentifier id and returns a list/array of the resource's Tags
 func getTagsFromName(id SecretIdentifier) []*ssm.Tag {
-	tagName1 := "env"
-	tagValue1 := id.EnvironmentString()
-	tagName2 := "app"
-	tagValue2 := id.Service
-	tagName3 := "name"
-	tagValue3 := id.Key
-
 	tags := []*ssm.Tag{
 		&ssm.Tag{
-			Key:   aws.String(tagName1),
-			Value: aws.String(tagValue1),
+			Key:   aws.String("env"),
+			Value: aws.String(id.EnvironmentString()),
 		},
 		&ssm.Tag{
-			Key:   aws.String(tagName2),
-			Value: aws.String(tagValue2),
+			Key:   aws.String("app"),
+			Value: aws.String(id.Service),
 		},
 		&ssm.Tag{
-			Key:   aws.String(tagName3),
-			Value: aws.String(tagValue3),
+			Key:   aws.String("name"),
+			Value: aws.String(id.Key),
 		},
 	}
 	return tags

--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
+	rgsAPI "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/pkg/errors"
 )
@@ -79,6 +80,32 @@ func getParamNameFromName(id SecretIdentifier) string {
 	return fmt.Sprintf("%s/%s", getNamespace(id.EnvironmentString(), id.Service), id.Key)
 }
 
+// getTagsFromName takes the SecretIdentifier id and returns a list/array of the resource's Tags
+func getTagsFromName(id SecretIdentifier) []rgsAPI.Tag {
+	tagName1 := "env"
+	tagValue1 := id.EnvironmentString()
+	tagName2 := "app"
+	tagValue2 := id.Service
+	tagName3 := "name"
+	tagValue3 := id.Key
+
+	tags := []rgsAPI.Tag{
+		{
+			Key:   aws.String(tagName1),
+			Value: aws.String(tagValue1),
+		},
+		{
+			Key:   aws.String(tagName2),
+			Value: aws.String(tagValue2),
+		},
+		{
+			Key:   aws.String(tagName3),
+			Value: aws.String(tagValue3),
+		},
+	}
+	return tags
+}
+
 // getParamNameFromNameAtVersion constructs AWS SSM paramname with version
 func getParamNameFromNameAtVersion(id SecretIdentifier, version int) string {
 	paramName := getParamNameFromName(id)
@@ -105,6 +132,8 @@ type ParameterStore struct {
 // Create creates a Secret in the secret store. Version is guaranteed to be zero if no error is returned.
 func (s *ParameterStore) Create(id SecretIdentifier, value string) error {
 	name := getParamNameFromName(id)
+	fmt.Println("this is name", name)
+	fmt.Println("this is value", value)
 	putParameterInput := &ssm.PutParameterInput{
 		Name:      aws.String(name),
 		Overwrite: aws.Bool(false), // false since we are creating a new secret

--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -136,6 +136,7 @@ func (s *ParameterStore) Create(id SecretIdentifier, value string) error {
 		Tags:      tags,
 		Value:     aws.String(value),
 	}
+
 	_, errors := s.readForAllRegions(getParamNameFromName(id))
 	for _, err := range errors {
 		// the secret exists in some regions, throw error

--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
-	rgsAPI "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/pkg/errors"
 )
@@ -81,7 +80,7 @@ func getParamNameFromName(id SecretIdentifier) string {
 }
 
 // getTagsFromName takes the SecretIdentifier id and returns a list/array of the resource's Tags
-func getTagsFromName(id SecretIdentifier) []rgsAPI.Tag {
+func getTagsFromName(id SecretIdentifier) []*ssm.Tag {
 	tagName1 := "env"
 	tagValue1 := id.EnvironmentString()
 	tagName2 := "app"
@@ -89,7 +88,7 @@ func getTagsFromName(id SecretIdentifier) []rgsAPI.Tag {
 	tagName3 := "name"
 	tagValue3 := id.Key
 
-	tags := []rgsAPI.Tag{
+	tags := []*ssm.Tag{
 		{
 			Key:   aws.String(tagName1),
 			Value: aws.String(tagValue1),
@@ -132,12 +131,12 @@ type ParameterStore struct {
 // Create creates a Secret in the secret store. Version is guaranteed to be zero if no error is returned.
 func (s *ParameterStore) Create(id SecretIdentifier, value string) error {
 	name := getParamNameFromName(id)
-	fmt.Println("this is name", name)
-	fmt.Println("this is value", value)
+	tags := getTagsFromName(id)
 	putParameterInput := &ssm.PutParameterInput{
 		Name:      aws.String(name),
 		Overwrite: aws.Bool(false), // false since we are creating a new secret
 		Type:      aws.String(ssm.ParameterTypeSecureString),
+		Tags:      tags,
 		Value:     aws.String(value),
 	}
 

--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -89,15 +89,15 @@ func getTagsFromName(id SecretIdentifier) []*ssm.Tag {
 	tagValue3 := id.Key
 
 	tags := []*ssm.Tag{
-		{
+		&ssm.Tag{
 			Key:   aws.String(tagName1),
 			Value: aws.String(tagValue1),
 		},
-		{
+		&ssm.Tag{
 			Key:   aws.String(tagName2),
 			Value: aws.String(tagValue2),
 		},
-		{
+		&ssm.Tag{
 			Key:   aws.String(tagName3),
 			Value: aws.String(tagValue3),
 		},
@@ -139,7 +139,6 @@ func (s *ParameterStore) Create(id SecretIdentifier, value string) error {
 		Tags:      tags,
 		Value:     aws.String(value),
 	}
-
 	_, errors := s.readForAllRegions(getParamNameFromName(id))
 	for _, err := range errors {
 		// the secret exists in some regions, throw error

--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -81,18 +81,22 @@ func getParamNameFromName(id SecretIdentifier) string {
 
 // getTagsFromName takes the SecretIdentifier id and returns a list/array of the resource's Tags
 func getTagsFromName(id SecretIdentifier) []*ssm.Tag {
+	env := id.EnvironmentString()
+	app := id.Service
+	name := id.Key
+
 	tags := []*ssm.Tag{
 		&ssm.Tag{
-			Key:   aws.String("env"),
-			Value: aws.String(id.EnvironmentString()),
+			Key:   aws.String("environment"),
+			Value: aws.String(env),
 		},
 		&ssm.Tag{
-			Key:   aws.String("app"),
-			Value: aws.String(id.Service),
+			Key:   aws.String("application"),
+			Value: aws.String(app),
 		},
 		&ssm.Tag{
-			Key:   aws.String("name"),
-			Value: aws.String(id.Key),
+			Key:   aws.String("key"),
+			Value: aws.String(name),
 		},
 	}
 	return tags

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -12,6 +14,33 @@ import (
 // Other possible tests
 // - keys shouldn't be case sensitive
 // - should fail if key contains invalid chars / format (must be [a-z0-9-])
+
+// TestMain runs deleteSecretsFromStores before running the tests
+func TestMain(m *testing.M) {
+	deleteSecretsFromStores()
+	code := m.Run()
+	os.Exit(code)
+}
+
+// deleteSecretsFromStores deletes all secrets from all stores
+func deleteSecretsFromStores() {
+	log.Println("Deleting secrets from all stores...")
+	for name, store := range Stores() {
+		ids, err := store.ListAll(CITestEnvironment)
+		if err != nil {
+			errMsg := fmt.Errorf("Unable to get secrets from %s. error: %s", name, err)
+			fmt.Println(errMsg)
+		} else if len(ids) > 0 {
+			for _, id := range ids {
+				store.Delete(id)
+			}
+			log.Printf("All secrets from %s successfully deleted", name)
+		} else {
+			log.Printf("No secrets in %s", name)
+		}
+	}
+	log.Println("End of deleting secrets from all stores")
+}
 
 func TestIdentifer(t *testing.T) {
 	id := SecretIdentifier{Environment: CITestEnvironment, Service: "service", Key: "foo"}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// deleteSecretsFromStores deletes all secrets from all stores
+// deleteSecretsFromStores deletes all secrets from all stores in CITestEnvironment
 func deleteSecretsFromStores() {
 	log.Println("Deleting secrets from all stores...")
 	for name, store := range Stores() {


### PR DESCRIPTION
JIRA:

[JIRA ticket](https://clever.atlassian.net/browse/SECNG-385)

Overview:

Part 1:
Created a function getTagsFromName that creates a list of resource Tags from a SecretIdentifier id. Currently, the Tags are being used as part of the secret parameter input. New secrets will now have tags for their environment, application, and name upon creation.

Part 2:
While testing, I ran into an issue where the test stores would not properly be cleaned of secrets when the tests were forcefully aborted before the cleanup steps of each test. Therefore, I added test store sanitization before tests run in order to make sure we start our tests with clean test stores.   

Testing:

Part 1:
In the terminal ran **make test**
All tests passed

Part 2:
In the terminal ran **make test**
While tests were running, force aborted using CTRL + C before cleanup happened in tests TestCreateRead and TestCreateList. 
Reran the tests again using **make test**. Saw the leftover secrets were being deleted with example print:

2021/02/05 21:29:42 Deleting secrets from all stores...
2021/02/05 21:29:49 All secrets from Paramstore successfully deleted
2021/02/05 21:29:49 No secrets in Memory
{"fields":{"name":"ci-test.testTR.GeGOPVKIti","version":"0000000000000000000"},"level":"info","timestamp":"2021-02-05T21:29:49.536997Z","message":"deleting"}
{"fields":{"name":"ci-test.testTR.wZABkbTWWz","version":"0000000000000000000"},"level":"info","timestamp":"2021-02-05T21:29:49.637038Z","message":"deleting"}
{"fields":{"name":"ci-test.testzY.oVoTXhTSAp","version":"0000000000000000000"},"level":"info","timestamp":"2021-02-05T21:29:49.724403Z","message":"deleting"}
2021/02/05 21:29:49 All secrets from Unicreds successfully deleted
2021/02/05 21:29:49 End of deleting secrets from all stores

Rest of the tests ran as normal and were successful.
