### PR TITLE
Detect when secrets value drifts happen with `health` command

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,10 @@ var (
 	writeService     = cmdWrite.Flag("service", "Service that the key belongs to.").Required().String()
 	writeKey         = cmdWrite.Flag("key", "Key to write.").Required().String()
 	writeValue       = cmdWrite.Flag("value", "Value to write.").Required().String()
+
+	cmdHealth         = app.Command("health", "Checks for health of all secrets for a service across 4 AWS regions, ensuring there is no discrepancies in values.")
+	healthEnvironment = cmdHealth.Flag("environment", "Environment that the secret belongs to.").Required().String()
+	healthService     = cmdHealth.Flag("service", "Service that the key belongs to.").Required().String()
 )
 
 func main() {
@@ -76,6 +80,36 @@ func main() {
 			log.Fatalf("Failed to write secret: %s", err)
 		}
 		fmt.Printf("Wrote secret %s\n", id.String())
+
+	case cmdHealth.FullCommand():
+		s := store.NewParameterStore(50)
+		var stateOfSecrets = map[string]string{}
+		for _, region := range s.GetOrderedRegions() {
+			s.ParamRegion = region
+			fmt.Printf("Checking store region %s\n", s.ParamRegion)
+			var secrets []store.SecretIdentifier
+			var err error
+			var secretValue store.Secret
+			if secrets, err = s.List(getEnvironment(*healthEnvironment), *healthService); err != nil {
+				log.Fatalf("Failed to list secrets for : %s in %s: %s", *healthService, *healthEnvironment, err)
+			}
+			for _, id := range secrets {
+				if val, ok := stateOfSecrets[id.String()]; ok {
+					if secretValue, err = s.Read(id); err != nil {
+						log.Fatalf("Error reading secret %s in region %s. %s \n", id.String(), region, err)
+					}
+					if secretValue.Data != val {
+						log.Fatalf("Secret %s differs in region %s from us-west-1. \n", id.String(), region)
+					}
+				} else {
+					if secretValue, err = s.Read(id); err != nil {
+						log.Fatalf("Error reading secret %s in region %s. %s \n", id.String(), region, err)
+					}
+					stateOfSecrets[id.String()] = secretValue.Data
+				}
+			}
+			fmt.Printf("Finished checking secrets in region %s.\n", region)
+		}
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -94,17 +94,14 @@ func main() {
 				log.Fatalf("Failed to list secrets for : %s in %s: %s", *healthService, *healthEnvironment, err)
 			}
 			for _, id := range secrets {
+				if secretValue, err = s.Read(id); err != nil {
+					fmt.Printf("Error reading secret %s in region %s. %s \n", id.String(), region, err)
+				}
 				if val, ok := stateOfSecrets[id.String()]; ok {
-					if secretValue, err = s.Read(id); err != nil {
-						log.Fatalf("Error reading secret %s in region %s. %s \n", id.String(), region, err)
-					}
 					if secretValue.Data != val {
-						log.Fatalf("Secret %s differs in region %s from us-west-1. \n", id.String(), region)
+						fmt.Printf("Secret %s differs in region %s from us-west-1. \n", id.String(), region)
 					}
 				} else {
-					if secretValue, err = s.Read(id); err != nil {
-						log.Fatalf("Error reading secret %s in region %s. %s \n", id.String(), region, err)
-					}
 					stateOfSecrets[id.String()] = secretValue.Data
 				}
 			}


### PR DESCRIPTION
https://clever.atlassian.net/browse/SECNG-1198

Adds `stealth health` command that, given (environment, service), checks all the values of the secrets of that service across  3 regions (west-2, east-1, east-2) against the values in west-1.


## Testing
Tested by 
1. manually overriding us-west-1 value for `development/who-is-who-syncer/slack-syncer-token`
2. `./stealth health --environment=development --service=who-is-who-syncer`
3. See
```
ulzii.o@Ulzii-Os-MacBook-Pro-J3WKTPHW9Q stealth % ./stealth health --environment=development --service=who-is-who-syncer
Checking store region us-west-1
Finished checking secrets in region us-west-1
Checking store region us-west-2
2022/08/02 16:01:02 Secret development.who-is-who-syncer.slack-syncer-token differs in region us-west-2 from us-west-1. 
```
4. Revert the value back and rerun the health command
5. See:
```
ulzii.o@Ulzii-Os-MacBook-Pro-J3WKTPHW9Q stealth % ./stealth health --environment=development --service=who-is-who-syncer
Checking store region us-west-1
Finished checking secrets in region us-west-1.
Checking store region us-west-2
Finished checking secrets in region us-west-2.
Checking store region us-east-1
Finished checking secrets in region us-east-1.
Checking store region us-east-2
Finished checking secrets in region us-east-2.
```