### PR TITLE
In CI, do not test these stores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
     description: Clone the ci-scripts repo
     steps:
     - run:
-        command: cd .. &&  git clone -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git checkout SECNG-1770 && git show --oneline -s
+        command: cd .. && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
         name: Clone ci-scripts
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     - clone-ci-scripts
     - run:
         name: Authenticate to AWS via role
-        command: . ../ci-scripts/circleci/utils && assume_role_with_web_identity $OIDC_STEALTH_ROLE default
+        command: . ../ci-scripts/circleci/utils && install_awscli && assume_role_with_web_identity $OIDC_STEALTH_ROLE default
     - run: make test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
     description: Clone the ci-scripts repo
     steps:
     - run:
-        command: cd .. && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+        command: cd .. && git clone -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git checkout SECNG-1770 && git show --oneline -s
         name: Clone ci-scripts
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
     description: Clone the ci-scripts repo
     steps:
     - run:
-        command: cd .. && git clone -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git checkout SECNG-1770 && git show --oneline -s
+        command: cd .. &&  git clone -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git checkout SECNG-1770 && git show --oneline -s
         name: Clone ci-scripts
 
 jobs:
@@ -51,8 +51,8 @@ jobs:
         command: mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=' >> ~/.ssh/known_hosts
     - clone-ci-scripts
     - run:
-        name: Source util functions
-        command: . $HOME/ci-scripts/circleci/utils && assume_role_with_web_identity $OIDC_STEALTH_ROLE default
+        name: Authenticate to AWS via role
+        command: . ../ci-scripts/circleci/utils && assume_role_with_web_identity $OIDC_STEALTH_ROLE default
     - run: make test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
     - run:
         name: Add github.com to known hosts
         command: mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=' >> ~/.ssh/known_hosts
+    - clone-ci-scripts
+    - run:
+        name: Source util functions
+        command: . $HOME/ci-scripts/circleci/utils && assume_role_with_web_identity $OIDC_STEALTH_ROLE default
     - run: make test
 
 workflows:
@@ -57,6 +61,7 @@ workflows:
     jobs:
     - build
     - unit-test:
+        context: aws-stealth-service
         requires:
         - build
     - publish:

--- a/store/test_utils.go
+++ b/store/test_utils.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"math/rand"
+	"os"
 	"time"
 )
 
@@ -9,9 +10,14 @@ import (
 func Stores() map[string]SecretStore {
 	var stores = make(map[string]SecretStore)
 	stores["Memory"] = NewMemoryStore()
-	stores["Unicreds"] = NewUnicredsStore()
-	// maxResultsToQuery = 5 so that we test the pagination logic of the List command
-	stores["Paramstore"] = NewParameterStore(5)
+	// enable testing of these store only in non-CI environments
+	ci := os.Getenv("CI")
+	isCI := (ci == "true")
+	if !isCI {
+		stores["Unicreds"] = NewUnicredsStore()
+		// maxResultsToQuery = 5 so that we test the pagination logic of the List command
+		stores["Paramstore"] = NewParameterStore(5)
+	}
 	return stores
 }
 

--- a/store/test_utils.go
+++ b/store/test_utils.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"math/rand"
-	"os"
 	"time"
 )
 
@@ -10,14 +9,9 @@ import (
 func Stores() map[string]SecretStore {
 	var stores = make(map[string]SecretStore)
 	stores["Memory"] = NewMemoryStore()
-	// enable testing of these store only in non-CI environments
-	ci := os.Getenv("CI")
-	isCI := (ci == "true")
-	if !isCI {
-		stores["Unicreds"] = NewUnicredsStore()
-		// maxResultsToQuery = 5 so that we test the pagination logic of the List command
-		stores["Paramstore"] = NewParameterStore(5)
-	}
+	stores["Unicreds"] = NewUnicredsStore()
+	// maxResultsToQuery = 5 so that we test the pagination logic of the List command
+	stores["Paramstore"] = NewParameterStore(5)
 	return stores
 }
 


### PR DESCRIPTION
When `make test` is run in CI, it tests `Unicreds` or `Paramstore`. Let us split the permissions needed for this from `ci` user into another role: `CircleCIOidcStealth`, which assist with https://clever.atlassian.net/browse/SECNG-1827.

*Testing*
Removed `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the CI env vars and added `aws-stealth-service` to enable role based auth into AWS. The tests still passes, highlighting that `CI` user is not being used here anymore!