### PR TITLE
fix ci-scripts path in publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     - attach_workspace:
         at: ~/go/src/github.com/Clever
     - clone-ci-scripts
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then ../ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;
 
   unit-test:
     executor: common-executor


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-6465

## Overview
Fixes github-release. Right now we get
```
#!/bin/bash -eo pipefail
if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;
/bin/bash: line 1: /home/circleci/ci-scripts/circleci/github-release: No such file or directory

Exited with code exit status 127
CircleCI received exit code 127
```

## Testing
Merge to `master` will verify this works
