### PR TITLE
add SecretsManagement assumption to write to OpsDev acct

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Stealth works with the IdentityEngineer SSO Role/Profile to write to the operati
     ./stealth write --assume --environment [production OR development] -- service [service-name] --key [key name] --value [key value]
 ```
 
-If you're using the --assume flag and you are encountering permission issues, try:
+If you're using the --assume flag and you are encountering permission issues, try the following before running stealth again:
 
 ```bash
     export AWS_PROFILE=[IdentityEngineer Profile Name]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ To identify discrepancies in secret values across 4 U.S. regions of AWS.
     ./stealth health --environment=ENVIRONMENT --service=SERVICE
 ```
 
+Stealth works with the IdentityEngineer SSO Role/Profile to write to the operations or operations-dev account (depending on the --environment value).
+```bash
+    ./stealth write --assume --environment [production OR development] -- service [service-name] --key [key name] --value [key value]
+```
+
+If you're using the --assume flag and you are encountering permission issues, try:
+
+```bash
+    export AWS_PROFILE=[IdentityEngineer Profile Name]
+```
+
 # tests
 
 To run tests, use:

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 	switch command {
 	case cmdDupes.FullCommand():
-		s := store.NewParameterStore(50)
+		s := store.NewParameterStore(50, *dupeEnvironment)
 		id := store.SecretIdentifier{Environment: getEnvironment(*dupeEnvironment), Service: *dupeService, Key: *dupeKey}
 		envs := []store.Environment{store.DevelopmentEnvironment, store.ProductionEnvironment}
 
@@ -66,14 +66,14 @@ func main() {
 			}
 		}
 	case cmdDelete.FullCommand():
-		s := store.NewParameterStore(50)
+		s := store.NewParameterStore(50, *deleteEnvironment)
 		id := store.SecretIdentifier{Environment: getEnvironment(*deleteEnvironment), Service: *deleteService, Key: *deleteKey}
 		if askForConfirmation("Are you sure you want to delete the secret " + id.String() + "?") {
 			s.Delete(id)
 		}
 
 	case cmdWrite.FullCommand():
-		s := store.NewParameterStore(50)
+		s := store.NewParameterStore(50, *writeEnvironment)
 		id := store.SecretIdentifier{Environment: getEnvironment(*writeEnvironment), Service: *writeService, Key: *writeKey}
 		// TODO: allow value to be a pointer to a file, or stdin
 		if err := createOrUpdate(s, id, *writeValue); err != nil {
@@ -82,7 +82,7 @@ func main() {
 		fmt.Printf("Wrote secret %s\n", id.String())
 
 	case cmdHealth.FullCommand():
-		s := store.NewParameterStore(50)
+		s := store.NewParameterStore(50, *healthEnvironment)
 		var stateOfSecrets = map[string]string{}
 		for _, region := range s.GetOrderedRegions() {
 			s.ParamRegion = region

--- a/main.go
+++ b/main.go
@@ -35,13 +35,15 @@ var (
 	cmdHealth         = app.Command("health", "Checks for health of all secrets for a service across 4 AWS regions, ensuring there is no discrepancies in values.")
 	healthEnvironment = cmdHealth.Flag("environment", "Environment that the secret belongs to.").Required().String()
 	healthService     = cmdHealth.Flag("service", "Service that the key belongs to.").Required().String()
+
+	assumeRole = app.Flag("assume", "If set, stealth will assume the SecretsManagement role (based on --environment)").Bool()
 )
 
 func main() {
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 	switch command {
 	case cmdDupes.FullCommand():
-		s := store.NewParameterStore(50, *dupeEnvironment)
+		s := store.NewParameterStore(50, *dupeEnvironment, *assumeRole)
 		id := store.SecretIdentifier{Environment: getEnvironment(*dupeEnvironment), Service: *dupeService, Key: *dupeKey}
 		envs := []store.Environment{store.DevelopmentEnvironment, store.ProductionEnvironment}
 
@@ -66,14 +68,14 @@ func main() {
 			}
 		}
 	case cmdDelete.FullCommand():
-		s := store.NewParameterStore(50, *deleteEnvironment)
+		s := store.NewParameterStore(50, *deleteEnvironment, *assumeRole)
 		id := store.SecretIdentifier{Environment: getEnvironment(*deleteEnvironment), Service: *deleteService, Key: *deleteKey}
 		if askForConfirmation("Are you sure you want to delete the secret " + id.String() + "?") {
 			s.Delete(id)
 		}
 
 	case cmdWrite.FullCommand():
-		s := store.NewParameterStore(50, *writeEnvironment)
+		s := store.NewParameterStore(50, *writeEnvironment, *assumeRole)
 		id := store.SecretIdentifier{Environment: getEnvironment(*writeEnvironment), Service: *writeService, Key: *writeKey}
 		// TODO: allow value to be a pointer to a file, or stdin
 		if err := createOrUpdate(s, id, *writeValue); err != nil {
@@ -82,7 +84,7 @@ func main() {
 		fmt.Printf("Wrote secret %s\n", id.String())
 
 	case cmdHealth.FullCommand():
-		s := store.NewParameterStore(50, *healthEnvironment)
+		s := store.NewParameterStore(50, *healthEnvironment, *assumeRole)
 		var stateOfSecrets = map[string]string{}
 		for _, region := range s.GetOrderedRegions() {
 			s.ParamRegion = region

--- a/main.go
+++ b/main.go
@@ -35,14 +35,14 @@ var (
 	cmdHealth         = app.Command("health", "Checks for health of all secrets for a service across 4 AWS regions, ensuring there is no discrepancies in values.")
 	healthEnvironment = cmdHealth.Flag("environment", "Environment that the secret belongs to.").Required().String()
 	healthService     = cmdHealth.Flag("service", "Service that the key belongs to.").Required().String()
-	assumeProfile     = app.Flag("assume-profile", "If set, stealth will use this AWS CLI profile for SSO and assume the SecretsManagement role for the given --environment.").String()
+	assumeRole        = app.Flag("assume", "If set, stealth will assume the SecretsManagement role (based on --environment)").Bool()
 )
 
 func main() {
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 	switch command {
 	case cmdDupes.FullCommand():
-		s := store.NewParameterStore(50, *dupeEnvironment, *assumeProfile)
+		s := store.NewParameterStore(50, *dupeEnvironment, *assumeRole)
 		id := store.SecretIdentifier{Environment: getEnvironment(*dupeEnvironment), Service: *dupeService, Key: *dupeKey}
 		envs := []store.Environment{store.DevelopmentEnvironment, store.ProductionEnvironment}
 
@@ -67,14 +67,14 @@ func main() {
 			}
 		}
 	case cmdDelete.FullCommand():
-		s := store.NewParameterStore(50, *deleteEnvironment, *assumeProfile)
+		s := store.NewParameterStore(50, *deleteEnvironment, *assumeRole)
 		id := store.SecretIdentifier{Environment: getEnvironment(*deleteEnvironment), Service: *deleteService, Key: *deleteKey}
 		if askForConfirmation("Are you sure you want to delete the secret " + id.String() + "?") {
 			s.Delete(id)
 		}
 
 	case cmdWrite.FullCommand():
-		s := store.NewParameterStore(50, *writeEnvironment, *assumeProfile)
+		s := store.NewParameterStore(50, *writeEnvironment, *assumeRole)
 		id := store.SecretIdentifier{Environment: getEnvironment(*writeEnvironment), Service: *writeService, Key: *writeKey}
 		// TODO: allow value to be a pointer to a file, or stdin
 		if err := createOrUpdate(s, id, *writeValue); err != nil {
@@ -83,7 +83,7 @@ func main() {
 		fmt.Printf("Wrote secret %s\n", id.String())
 
 	case cmdHealth.FullCommand():
-		s := store.NewParameterStore(50, *healthEnvironment, *assumeProfile)
+		s := store.NewParameterStore(50, *healthEnvironment, *assumeRole)
 		var stateOfSecrets = map[string]string{}
 		for _, region := range s.GetOrderedRegions() {
 			s.ParamRegion = region

--- a/store/test_utils.go
+++ b/store/test_utils.go
@@ -18,7 +18,7 @@ func Stores() map[string]SecretStore {
 	// don't want to support
 	if !isCI() {
 		// maxResultsToQuery = 5 so that we test the pagination logic of the List command, in the ci-test env
-		stores["Paramstore"] = NewParameterStore(5, "ci-test")
+		stores["Paramstore"] = NewParameterStore(5, "ci-test", false)
 	}
 	return stores
 }

--- a/store/test_utils.go
+++ b/store/test_utils.go
@@ -18,7 +18,7 @@ func Stores() map[string]SecretStore {
 	// don't want to support
 	if !isCI() {
 		// maxResultsToQuery = 5 so that we test the pagination logic of the List command, in the ci-test env
-		stores["Paramstore"] = NewParameterStore(5, "ci-test", "identityengineer")
+		stores["Paramstore"] = NewParameterStore(5, "ci-test", false)
 	}
 	return stores
 }

--- a/store/test_utils.go
+++ b/store/test_utils.go
@@ -18,7 +18,7 @@ func Stores() map[string]SecretStore {
 	// don't want to support
 	if !isCI() {
 		// maxResultsToQuery = 5 so that we test the pagination logic of the List command, in the ci-test env
-		stores["Paramstore"] = NewParameterStore(5, "ci-test", false)
+		stores["Paramstore"] = NewParameterStore(5, "ci-test", "identityengineer")
 	}
 	return stores
 }

--- a/store/test_utils.go
+++ b/store/test_utils.go
@@ -17,8 +17,8 @@ func Stores() map[string]SecretStore {
 	// don't test in CI environment, since it would require a role assumption we
 	// don't want to support
 	if !isCI() {
-		// maxResultsToQuery = 5 so that we test the pagination logic of the List command
-		stores["Paramstore"] = NewParameterStore(5)
+		// maxResultsToQuery = 5 so that we test the pagination logic of the List command, in the ci-test env
+		stores["Paramstore"] = NewParameterStore(5, "ci-test")
 	}
 	return stores
 }


### PR DESCRIPTION
## Overview

**Jira**: [SECNG_3509](https://clever.atlassian.net/browse/SECNG-3509)

Stealth can write a secret in Ops Dev account, via role assumption of SecretManagement role. 

Left a place to specify the role to be use for the Operations prod account (when the production environment is specified in the command). This is a TODO to update that value for when that role is created.

## Testing
Ran `./stealth write --environment development --service audrey --key test1 --value testval` as the IdentityEngineer role and verified that secret was added in the OpsDev account.

## Rollout

