### PR TITLE
Update to remove bug of duplicates in ark secrets list

### DIFF
--- a/store/parameter_store.go
+++ b/store/parameter_store.go
@@ -362,7 +362,16 @@ func (s *ParameterStore) List(env Environment, service string) ([]SecretIdentifi
 		// retry again in a second
 		time.Sleep(1 * time.Second)
 	}
-	return results, nil
+	// collapse any duplicate SecretIdentifiers (same Env,Service,Key)
+	unique := make(map[SecretIdentifier]struct{}, len(results))
+	deduped := make([]SecretIdentifier, 0, len(results))
+	for _, ident := range results {
+		if _, seen := unique[ident]; !seen {
+			unique[ident] = struct{}{}
+			deduped = append(deduped, ident)
+		}
+	}
+	return deduped, nil
 }
 
 // ListAll gets all secrets within a environment (env)>


### PR DESCRIPTION
## Overview

**Jira**: [SECNG_3521](https://clever.atlassian.net/browse/SECNG-3521)

**Description**
ark secrets was seeing duplicates when listing secrets. This is occurring post-merge of this [PR](https://github.com/Clever/catapult/pull/2363)

I believe the reason we're seeing dozens of copies of each key is that after #2363 every deploy writes a new SSM parameter under `/<env>/<service>/<key>/<deploy-suffix>`

Stealth’s List method does a DescribeParameters…Recursive on /env/service and then for each “parameter name” calls:
`ident, _ := getSecretIDFromParamName(result.Name)
resultsPerTry = append(resultsPerTry, ident)
`

Because getSecretIDFromParamName("/env/service/foo/20250428-abc123") still returns
```
SecretIdentifier{
    Environment: DevelopmentEnvironment,
    Service:     "service",
    Key:         "foo",
}
```
you end up with one ident per suffix—and thus duplicates.

This PR updates the List method to de-duplicate on (env,service,key)

The goal of the changes in this PR are to:

1. Build the full results slice exactly as before (including one entry per suffix).
2. Fold it down into deduped by keeping the first occurrence of each (env,service,key).
3. Return only the unique keys.

With the change, ark secrets list production.otel-aggregator should once again show each secret key exactly once, regardless of how many historical-suffixed parameters exist under the hood.

## Testing
Ran make test and passed
<details>
```
FORMATTING github.com/Clever/stealth...
LINTING github.com/Clever/stealth...
VETTING github.com/Clever/stealth...
TESTING github.com/Clever/stealth...
?   	github.com/Clever/stealth	[no test files]
FORMATTING github.com/Clever/stealth/store...
LINTING github.com/Clever/stealth/store...
/Users/audrey.gan/Documents/GitHub/stealth/store/parameter_store.go:18:5: exported var DefaultRegion should have comment or be unexported
/Users/audrey.gan/Documents/GitHub/stealth/store/parameter_store.go:19:5: exported var Region should have comment or be unexported
VETTING github.com/Clever/stealth/store...
TESTING github.com/Clever/stealth/store...
2025/04/29 23:26:55 Deleting secrets from all stores...
2025/04/29 23:26:55 No secrets in Memory
2025/04/29 23:26:59 No secrets in Paramstore
2025/04/29 23:26:59 End of deleting secrets from all stores
=== RUN   TestIdentifer
--- PASS: TestIdentifer (0.00s)
=== RUN   TestStringToSecretIdentifier
    store_test.go:52: works for all valid environments
    store_test.go:61: errors on invalid environment
    store_test.go:68: errors on '.' in key name: ci-test.service.foo.bar
--- PASS: TestStringToSecretIdentifier (0.00s)
=== RUN   TestCreateRead
    store_test.go:81: ---- Memory ----
    store_test.go:82: no secrets exist, to begin
    store_test.go:87: write a secret
    store_test.go:92: we should now be able to read it
    store_test.go:97: creating the secret again fails
    store_test.go:81: ---- Paramstore ----
    store_test.go:82: no secrets exist, to begin
    store_test.go:87: write a secret
    store_test.go:92: we should now be able to read it
    store_test.go:97: creating the secret again fails
--- PASS: TestCreateRead (5.16s)
=== RUN   TestCreateList
    store_test.go:120: ---- Memory ----
    store_test.go:122: errors if given invalid environment
    store_test.go:126: no secrets exist, to begin
    store_test.go:131: write 1st secret for service 1
    store_test.go:135: we should now be able to list 1 secret id
    store_test.go:141: write 2nd secret for service 1
    store_test.go:145: write 1st secret for service 2
    store_test.go:152: we should now be able to list 2 secret ids for service 1
    store_test.go:159: we should now be able to list 1 secret id for service 2
    store_test.go:164: we should now be able to list all secrets ids for service 1 and 2
    store_test.go:120: ---- Paramstore ----
    store_test.go:122: errors if given invalid environment
    store_test.go:126: no secrets exist, to begin
    store_test.go:131: write 1st secret for service 1
    store_test.go:135: we should now be able to list 1 secret id
    store_test.go:141: write 2nd secret for service 1
    store_test.go:145: write 1st secret for service 2
    store_test.go:152: we should now be able to list 2 secret ids for service 1
    store_test.go:159: we should now be able to list 1 secret id for service 2
    store_test.go:164: we should now be able to list all secrets ids for service 1 and 2
--- PASS: TestCreateList (20.01s)
=== RUN   TestCreateListMultipleTimes
    store_test.go:177: ---- Memory ----
    store_test.go:183: write secret #1 ci-test.testmn.bOpElNqhsI for service
    store_test.go:183: write secret #2 ci-test.testmn.GhhiECnkyp for service
    store_test.go:183: write secret #3 ci-test.testmn.DWeDCWeDpV for service
    store_test.go:183: write secret #4 ci-test.testmn.zdwnDYJgTi for service
    store_test.go:183: write secret #5 ci-test.testmn.rfyhrufhzZ for service
    store_test.go:183: write secret #6 ci-test.testmn.LgwMRJXVlo for service
    store_test.go:183: write secret #7 ci-test.testmn.GxiwURRTJe for service
    store_test.go:183: write secret #8 ci-test.testmn.FfboUbunOV for service
    store_test.go:183: write secret #9 ci-test.testmn.ZpauoIfUcp for service
    store_test.go:183: write secret #10 ci-test.testmn.cALZMHRLVr for service
    store_test.go:193: we should now be able to list secrets and match the count
    store_test.go:177: ---- Paramstore ----
    store_test.go:183: write secret #1 ci-test.testPs.volQaekNlB for service
    store_test.go:183: write secret #2 ci-test.testPs.wwaujBSEGy for service
    store_test.go:183: write secret #3 ci-test.testPs.YunHNKwWFQ for service
    store_test.go:183: write secret #4 ci-test.testPs.fcIRIIAubm for service
    store_test.go:183: write secret #5 ci-test.testPs.zxdjiZdiUh for service
    store_test.go:183: write secret #6 ci-test.testPs.ZxXRIWVyMa for service
    store_test.go:183: write secret #7 ci-test.testPs.ilwwtPlDVz for service
    store_test.go:183: write secret #8 ci-test.testPs.rrvaBgNYeG for service
    store_test.go:183: write secret #9 ci-test.testPs.kOLmHXRVNk for service
    store_test.go:183: write secret #10 ci-test.testPs.TgztRFiDPZ for service
    store_test.go:193: we should now be able to list secrets and match the count
--- PASS: TestCreateListMultipleTimes (43.04s)
=== RUN   TestUpdateHistory
    store_test.go:209: ---- Paramstore ----
    store_test.go:210: no secrets exist, to begin
    store_test.go:222: STEP 1: write a secret
    store_test.go:226: we should now see one version in History
    store_test.go:232: Read should return the most recent secret
    store_test.go:237: STEP 2: overwrite the secret
    store_test.go:242: we should now see two versions in History
    store_test.go:249: Read should return the most recent secret
    store_test.go:253: we should now be able to read the previous version
    store_test.go:258: we should now be able to read the current version
    store_test.go:263: we should not be able to read an non-existant version
    store_test.go:268: we should not be able to read a version less than zero
    store_test.go:209: ---- Memory ----
    store_test.go:210: no secrets exist, to begin
    store_test.go:222: STEP 1: write a secret
    store_test.go:226: we should now see one version in History
    store_test.go:232: Read should return the most recent secret
    store_test.go:237: STEP 2: overwrite the secret
    store_test.go:242: we should now see two versions in History
    store_test.go:249: Read should return the most recent secret
    store_test.go:253: we should now be able to read the previous version
    store_test.go:258: we should now be able to read the current version
    store_test.go:263: we should not be able to read an non-existant version
    store_test.go:268: we should not be able to read a version less than zero
--- PASS: TestUpdateHistory (7.39s)
=== RUN   TestDelete
    store_test.go:283: ---- Memory ----
    store_test.go:284: creating secret
    store_test.go:288: deleting secret
    store_test.go:292: we should not be able to read
    store_test.go:297: we should see no history
    store_test.go:283: ---- Paramstore ----
    store_test.go:284: creating secret
    store_test.go:288: deleting secret
    store_test.go:292: we should not be able to read
    store_test.go:297: we should see no history
--- PASS: TestDelete (4.40s)
PASS
ok  	github.com/Clever/stealth/store	83.904s
FORMATTING github.com/Clever/stealth/store/util...
LINTING github.com/Clever/stealth/store/util...
VETTING github.com/Clever/stealth/store/util...
TESTING github.com/Clever/stealth/store/util...
=== RUN   TestFindDupes
    dupes_test.go:20: ---- Memory ----
    dupes_test.go:21: creating some duplicate secrets
    dupes_test.go:27: should be able to find dupes for either duplicate value
2025/04/29 23:28:21 reading from ci
2025/04/29 23:28:21 total secrets: 3
2025/04/29 23:28:21 reading 0000/0003
2025/04/29 23:28:21 reading from ci
2025/04/29 23:28:21 total secrets: 3
2025/04/29 23:28:21 reading 0000/0003
    dupes_test.go:36: a secret with no duplicate should only return itself
2025/04/29 23:28:21 reading from ci
2025/04/29 23:28:21 total secrets: 3
2025/04/29 23:28:21 reading 0000/0003
    dupes_test.go:20: ---- Paramstore ----
    dupes_test.go:21: creating some duplicate secrets
    dupes_test.go:27: should be able to find dupes for either duplicate value
2025/04/29 23:28:27 reading from ci
2025/04/29 23:28:29 total secrets: 3
2025/04/29 23:28:29 reading 0000/0003
2025/04/29 23:28:30 reading from ci
2025/04/29 23:28:33 total secrets: 3
2025/04/29 23:28:33 reading 0000/0003
    dupes_test.go:36: a secret with no duplicate should only return itself
2025/04/29 23:28:34 reading from ci
2025/04/29 23:28:36 total secrets: 3
2025/04/29 23:28:36 reading 0000/0003
--- PASS: TestFindDupes (18.09s)
PASS
ok  	github.com/Clever/stealth/store/util	18.320s
```
</details>
